### PR TITLE
Update Rekor configuration with new shard and origin

### DIFF
--- a/distributor/config.yaml
+++ b/distributor/config.yaml
@@ -16,11 +16,9 @@ Logs:
   - Origin: rekor.sigstore.dev - 3904496407287907110
     PublicKeyType: ecdsa
     PublicKey: rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
-    ID: 3904496407287907110
   - Origin: rekor.sigstore.dev - 2605736670972794746
     PublicKeyType: ecdsa
     PublicKey: rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
-    ID: 2605736670972794746
   - Origin: DEFAULT
     PublicKeyType: ecdsa
     PublicKey: pixel6_transparency_log+72c878db+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFPN7lzVIk2BOd3Nk33VpqqVttGwV8uChH+RX/HVfBiypVQFyh8o8Ny6fSdxNMgkSf9/VynrgADBeys0r4Q9uPA=


### PR DESCRIPTION
Rekor is now sharded, so we specify the tree ID in the origin, and each shard has its own key.